### PR TITLE
dest needs to be outside of options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,14 +38,12 @@ module.exports = function(grunt) {
       },
       dev: {
         options: {
-          beautify: true,
-          dest: 'src/esri'
-        }
+          beautify: true
+        },
+        dest: 'src/esri'
       },
       travis: {
-        options: {
-          dest: 'src/esri'
-        }
+        dest: 'src/esri'
       }
     },
     nodeunit: {

--- a/README.md
+++ b/README.md
@@ -34,14 +34,12 @@ module.exports = function (grunt) {
       },
       dev: {
         options: {
-          beautify: true,
-          dest: 'src/esri'
-        }
+          beautify: true
+        },
+        dest: 'src/esri'
       },
       travis: {
-        options: {
-          dest: 'src/esri'
-        }
+        dest: 'src/esri'
       }
     }
   });


### PR DESCRIPTION
If `dest` is under options, Grunt reads it as `options.dest` and you get this error:

``` bash
Running "esri_slurp:dev" (esri_slurp) task
Warning: Cannot read property 'dest' of undefined Use --force to continue.

Aborted due to warnings.
```

In order to be read as `files.dest` it has to be at the root of the target.
