### PR TITLE
Update readme with hyperlink to AGRC BP repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ A string value letting grunt know where to put the downloaded files.
 
 ## Examples
 
-For examples for working with `grunt-esri-slurp` please browse the [AGRC JavaScript BoilerPlate]() project as well as [@TomWayson](https://github.com/tomwayson)'s simple [slurp example](https://github.com/tomwayson/esri-slurp-example).
+For examples for working with `grunt-esri-slurp` please browse the [AGRC JavaScript BoilerPlate](https://github.com/agrc/AGRCJavaScriptProjectBoilerPlate) project as well as [@TomWayson](https://github.com/tomwayson)'s simple [slurp example](https://github.com/tomwayson/esri-slurp-example).
 
 ## Release History
 **1.3.0** Added esri js api `3.12` modules. Create modules grunt task improvements.


### PR DESCRIPTION
The hyperlink was live, but was pointing to a 404 location (./master/blob of this repo). Hope this is the right hyperlink it was supposed to be pointing to.
Esri Slurp is awesome by the way.