### PR TITLE
remove references to create modules because the logic is now in esrislurp

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,13 +46,6 @@ module.exports = function(grunt) {
         dest: 'src/esri'
       }
     },
-    esri_slurp_modules:{
-      options: {
-        version: version,
-        src: './',
-        dest: './modules'
-      }
-    },
     nodeunit: {
       tests: ['test/*_test.js']
     },
@@ -75,8 +68,6 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['clean', 'jshint', 'nodeunit']);
 
   grunt.registerTask('default', ['jshint', 'esri_slurp:dev']);
-
-  grunt.registerTask('create_modules', ['esri_slurp_modules']);
 
   grunt.registerTask('travis', ['jshint', 'esri_slurp:travis', 'nodeunit']);
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "async": "^1.x",
-    "esrislurp": "1.1.0",
+    "esrislurp": "git://github.com/phillipgreenii/esrislurp.git#compactmode",
     "mkdirp": "^0.x",
     "progress": "^1.x"
   },

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -8,12 +8,7 @@
 
 'use strict';
 var esrislurp = require('esrislurp'),
-  ProgressBar = require('progress'),
-  mb = require('esrislurp/esriModuleBuilder'),
-  fs = require('fs'),
-  mkdirp = require('mkdirp'),
-  path = require('path'),
-  async = require('async');
+  ProgressBar = require('progress');
 
 module.exports = function(grunt) {
   grunt.registerMultiTask('esri_slurp', 'download esri js api amd modules and create a package', function() {
@@ -53,54 +48,5 @@ module.exports = function(grunt) {
     grunt.log.subhead('downloading and processing esri version ' + options.version);
 
     esrislurp(this.files[0].dest, options.version, options.beautify, onSuccess, onError, onProgress);
-  });
-
-  grunt.registerTask('esri_slurp_modules', 'create the module list the esri download', function() {
-    var options = this.options({
-        version: null,
-        src: null,
-        dest: null
-      }),
-      done = this.async();
-
-    if (!options.version || !options.src || !options.dest) {
-      grunt.fail.warn('version option is required and the dest file property must be set on the target.');
-    }
-    grunt.log.ok();
-
-    function onSuccess(data) {
-      grunt.log.writeln();
-      mkdirp.sync(options.dest);
-      var location = path.join(options.dest, 'esriModules-' + options.version + '.js');
-      grunt.log.write('creating ' + location);
-      fs.writeFile(location, data, 'binary', function(err) {
-        if (err) {
-          grunt.log.error('Unable to save module list ', err);
-        }
-      });
-      done();
-    }
-
-    function onError(error) {
-      grunt.log.error('Unable to slurp Esri JS API into module list: ', error);
-      done(false);
-    }
-
-    var bar;
-
-    function onProgress(progress) {
-      if (!bar) {
-        bar = new ProgressBar('[:bar] :elapseds', {
-          total: 2500, // TODO: just making this up for now
-          stream: process.stdout,
-          width: 25
-        });
-      }
-      bar.tick();
-    }
-
-    grunt.log.subhead('Processing version ' + options.version);
-
-    mb(options.src, options.version, onSuccess, onError, onProgress);
   });
 };


### PR DESCRIPTION
this removes the old code to generate modules for esrislurp since that logic has been moved into esrislurp via steveoh/esrislurp#11
